### PR TITLE
player index of '0' != false

### DIFF
--- a/game.js
+++ b/game.js
@@ -66,7 +66,7 @@ function onClientDisconnect() {
 	var removePlayer = playerById(this.id);
 
 	// Player not found
-	if (!removePlayer) {
+	if (removePlayer === false) {
 		util.log("Player not found: "+this.id);
 		return;
 	};


### PR DESCRIPTION
When player at index 0

```
players[0];
```

leaves, it should remove them from the players array. Without this change, javascript returns '0' from the playerByID function, and it is interpreted as 'false'. The player id is then left in the array, leaving one player always active.

Also, I'm so new it hurts. I was just working through your example from a few years ago, found this error, and figure its time to try baby's first pull request. Thanks if you approve.
